### PR TITLE
Fix "innerTalkback" typo in autoload/callbag.vim

### DIFF
--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1126,7 +1126,7 @@ function! s:flattenTalkbackCallback(data, t, d) abort
         endif
     endif
     if a:t == 2
-        if a:data['innertTalkback'] != 0 | call a:data['innerTalkback'](2, callbag#undefined()) | endif
+        if a:data['innerTalkback'] != 0 | call a:data['innerTalkback'](2, callbag#undefined()) | endif
         call a:data['outerTalkback'](2, callbag#undefined())
     endif
 endfunction


### PR DESCRIPTION
Ref https://github.com/prabirshrestha/vim-lsp/pull/929. 