### PR TITLE
add callbag#spawn() for vim8 and neovim jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Lightweight observables and iterables for VimScript based on [Callbag Spec](http
 |---------------|--------------------------------------------------------|
 | Yes           | spawn                                                  |
 
-`spawn` is currently only implemented for Vim8. It doesn't support `stdin` yet.
+`spawn` uses `job_start` in Vim8+ and `jobstart` in Neovim.
+`stdin` is currently not supported.
 
 ## Utils
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Lightweight observables and iterables for VimScript based on [Callbag Spec](http
 | Yes           | spawn                                                  |
 
 `spawn` uses `job_start` in Vim8+ and `jobstart` in Neovim.
-`stdin` is currently not supported.
 
 ## Utils
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Lightweight observables and iterables for VimScript based on [Callbag Spec](http
 | No            | throttle                                               |
 | No            | timeout                                                |
 
+## Vim Job and Channels
+
+| Implemented   | Name                                                   |
+|---------------|--------------------------------------------------------|
+| Yes           | spawn                                                  |
+
+`spawn` is currently only implemented for Vim8. It doesn't support `stdin` yet.
+
 ## Utils
 
 | Implemented   | Name                                                   |

--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1413,7 +1413,8 @@ endfunction
 "   \ 'exit': 1,
 "   \ 'pid': 1,
 "   \ 'failOnNonZeroExitCode': 1,
-"   \ 'normalize': 'raw' | 'string' | 'array', (defaults to raw)
+"   \ 'normalize': 'raw' | 'string' | 'array', (defaults to raw),
+"   \ 'env': {},
 "   \ })
 function! callbag#spawn(cmd, ...) abort
     let l:data = { 'cmd': a:cmd, 'opt': a:0 > 0 ? copy(a:000[0]) : {} }
@@ -1437,15 +1438,17 @@ function! s:spawn(data, start, sink) abort
         endif
         if get(a:data['opt'], 'stdout', 1) | let a:data['jobopt']['on_stdout'] = function('s:spawnNeovimOnStdout', [a:data]) | endif
         if get(a:data['opt'], 'stderr', 1) | let a:data['jobopt']['on_stderr'] = function('s:spawnNeovimOnStderr', [a:data]) | endif
+        if has_key(a:data['opt'], 'env') | let a:data['jobopt']['env'] = a:data['opt']['env'] | endif
         let a:data['jobid'] = jobstart(a:data['cmd'], a:data['jobopt'])
     else
         let a:data['jobopt'] = {
             \ 'exit_cb': function('s:spawnVimExitCb', [a:data]),
             \ 'close_cb': function('s:spawnVimCloseCb', [a:data]),
             \ }
+        if has('patch-8.1.350') | let a:data['jobopt']['noblock'] = 1 | endif
         if get(a:data['opt'], 'stdout', 1) | let a:data['jobopt']['out_cb'] = function('s:spawnVimOutCb', [a:data]) | endif
         if get(a:data['opt'], 'stderr', 1) | let a:data['jobopt']['err_cb'] = function('s:spawnVimErrCb', [a:data]) | endif
-        if has('patch-8.1.350') | let a:data['jobopt']['noblock'] = 1 | endif
+        if has_key(a:data['opt'], 'env') | let a:data['jobopt']['env'] = a:data['opt']['env'] | endif
         if l:normalize ==# 'array'
             let a:data['normalize'] = function('s:spawnNormalizeVimArray')
         else

--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1417,43 +1417,81 @@ function! s:spawn(data, start, sink) abort
     let a:data['sink'] = a:sink
     let a:data['close'] = 0
     let a:data['exit'] = 0
-    let a:data['jobopt'] = {
-        \ 'exit_cb': function('s:spawnExitCb', [a:data]),
-        \ 'close_cb': function('s:spawnCloseCb', [a:data]),
-        \ }
-    if get(a:data['opt'], 'stdout', 1)
-        let a:data['jobopt']['out_cb'] = function('s:spawnOutCb', [a:data])
+    if has('nvim')
+        let a:data['jobopt'] = {
+            \ 'on_exit': function('s:spawnNeovimOnExit', [a:data])
+            \ }
+        if get(a:data['opt'], 'stdout', 1)
+            let a:data['jobopt']['on_stdout'] = function('s:spawnNeovimOnStdout', [a:data])
+        endif
+        if get(a:data['opt'], 'stderr', 1)
+            let a:data['jobopt']['on_stderr'] = function('s:spawnNeovimOnStderr', [a:data])
+        endif
+        let a:data['jobid'] = jobstart(a:data['cmd'], a:data['jobopt'])
+    else
+        let a:data['jobopt'] = {
+            \ 'exit_cb': function('s:spawnVimExitCb', [a:data]),
+            \ 'close_cb': function('s:spawnVimCloseCb', [a:data]),
+            \ }
+        if get(a:data['opt'], 'stdout', 1)
+            let a:data['jobopt']['out_cb'] = function('s:spawnVimOutCb', [a:data])
+        endif
+        if get(a:data['opt'], 'stderr', 1)
+            let a:data['jobopt']['err_cb'] = function('s:spawnVimErrCb', [a:data])
+        endif
+        if has('patch-8.1.350')
+            let a:data['jobopt']['noblock'] = 1
+        endif
+        let l:job = job_start(a:data['cmd'], a:data['jobopt'])
+        let l:channel = job_getchannel(l:job)
+        let a:data['jobid'] = ch_info(l:channel)['id']
     endif
-    if get(a:data['opt'], 'stderr', 1)
-        let a:data['jobopt']['err_cb'] = function('s:spawnErrCb', [a:data])
-    endif
-    if has('patch-8.1.350')
-        let a:data['jobopt']['noblock'] = 1
-    endif
-    let l:job = job_start(a:data['cmd'], a:data['jobopt'])
-    let l:channel = job_getchannel(l:job)
-    let a:data['jobid'] = ch_info(l:channel)['id']
     call a:sink(0, function('s:spawnSinkCallback', [a:data]))
 endfunction
 
 function! s:spawnSinkCallback(data, t, ...) abort
     if a:t == 2
         let l:jobid = get(a:data, 'jobid', 0)
-        if l:jobid > 0 && job_status(l:jobid) ==? 'run'
-            call job_stop(a:data['jobid'])
+        if l:jobid > 0
+            if has('nvim')
+                try
+                    call jobstop(a:data['jobid'])
+                catch /^Vim\%((\a\+)\)\=:E900/
+                    " NOTE:
+                    " Vim does not raise exception even the job has already closed so fail
+                    " silently for 'E900: Invalid job id' exception
+                endtry
+            else
+                call job_stop(a:data['jobid'])
+            endif
         endif
     endif
 endfunction
 
-function! s:spawnOutCb(data, id, d) abort
+function! s:spawnNeovimOnStdout(data, id, d, event) abort
     call a:data['sink'](1, { 'event': 'stdout', 'data': a:d })
 endfunction
 
-function! s:spawnErrCb(data, id, d) abort
+function! s:spawnNeovimOnStderr(data, id, d, event) abort
     call a:data['sink'](1, { 'event': 'stderr', 'data': a:d })
 endfunction
 
-function! s:spawnExitCb(data, id, d) abort
+function! s:spawnNeovimOnExit(data, id, d, event) abort
+    let a:data['exit'] = 1
+    let a:data['close'] = 1
+    let a:data['exitcode'] = a:d
+    call s:spawnNotifyExit(a:data)
+endfunction
+
+function! s:spawnVimOutCb(data, id, d, ...) abort
+    call a:data['sink'](1, { 'event': 'stdout', 'data': a:d })
+endfunction
+
+function! s:spawnVimErrCb(data, id, d, ...) abort
+    call a:data['sink'](1, { 'event': 'stderr', 'data': a:d })
+endfunction
+
+function! s:spawnVimExitCb(data, id, d) abort
     let a:data['exit'] = 1
     let a:data['exitcode'] = a:d
     " for more info refer to :h job-start
@@ -1466,7 +1504,7 @@ function! s:spawnExitCb(data, id, d) abort
     endif
 endfunction
 
-function! s:spawnCloseCb(data, id) abort
+function! s:spawnVimCloseCb(data, id) abort
     let a:data['close'] = 1
     if a:data['close'] && a:data['exit']
         call s:spawnNotifyExit(a:data)

--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1447,8 +1447,20 @@ function! s:spawn(data, start, sink) abort
         let a:data['jobid'] = ch_info(l:channel)['id']
     endif
     call a:sink(0, function('s:spawnSinkCallback', [a:data]))
-    let l:startdata = { 'jobid': a:data['jobid'] }
-    call a:sink(1, { 'event': 'start', 'data': l:startdata })
+    if get(a:data['opt'], 'start', 1)
+        let l:startdata = { 'jobid': a:data['jobid'] }
+        if get(a:data['opt'], 'pid', 0)
+            if has('nvim')
+                let l:startdata['pid'] = jobpid(a:data['jobid'])
+            else
+                let l:jobinfo = job_info(l:job)
+                if type(l:jobinfo) == type({}) && has_key(l:jobinfo, 'process')
+                    let l:startdata['pid'] = l:jobinfo['process']
+                endif
+            endif
+        endif
+        call a:sink(1, { 'event': 'start', 'data': l:startdata })
+    endif
 endfunction
 
 function! s:spawnSinkCallback(data, t, ...) abort

--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1447,6 +1447,8 @@ function! s:spawn(data, start, sink) abort
         let a:data['jobid'] = ch_info(l:channel)['id']
     endif
     call a:sink(0, function('s:spawnSinkCallback', [a:data]))
+    let l:startdata = { 'jobid': a:data['jobid'] }
+    call a:sink(1, { 'event': 'start', 'data': l:startdata })
 endfunction
 
 function! s:spawnSinkCallback(data, t, ...) abort

--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1408,7 +1408,7 @@ endfunction
 
 " spawn {{{
 function! callbag#spawn(cmd, ...) abort
-    let l:data = { 'cmd': a:cmd, 'opt': a:0 > 0 ? a:000[0] : {} }
+    let l:data = { 'cmd': a:cmd, 'opt': a:0 > 0 ? copy(a:000[0]) : {} }
     return function('s:spawn', [l:data])
 endfunction
 
@@ -1417,30 +1417,31 @@ function! s:spawn(data, start, sink) abort
     let a:data['sink'] = a:sink
     let a:data['close'] = 0
     let a:data['exit'] = 0
+    let l:normalize = get(a:data['opt'], 'normalize', 'raw')
     if has('nvim')
         let a:data['jobopt'] = {
-            \ 'on_exit': function('s:spawnNeovimOnExit', [a:data])
+            \ 'on_exit': function('s:spawnNeovimOnExit', [a:data]),
             \ }
-        if get(a:data['opt'], 'stdout', 1)
-            let a:data['jobopt']['on_stdout'] = function('s:spawnNeovimOnStdout', [a:data])
+        if l:normalize ==# 'string'
+            let a:data['normalize'] = function('s:spawnNormalizeNeovimString')
+        else
+            let a:data['normalize'] = function('s:spawnNormalizeRaw')
         endif
-        if get(a:data['opt'], 'stderr', 1)
-            let a:data['jobopt']['on_stderr'] = function('s:spawnNeovimOnStderr', [a:data])
-        endif
+        if get(a:data['opt'], 'stdout', 1) | let a:data['jobopt']['on_stdout'] = function('s:spawnNeovimOnStdout', [a:data]) | endif
+        if get(a:data['opt'], 'stderr', 1) | let a:data['jobopt']['on_stderr'] = function('s:spawnNeovimOnStderr', [a:data]) | endif
         let a:data['jobid'] = jobstart(a:data['cmd'], a:data['jobopt'])
     else
         let a:data['jobopt'] = {
             \ 'exit_cb': function('s:spawnVimExitCb', [a:data]),
             \ 'close_cb': function('s:spawnVimCloseCb', [a:data]),
             \ }
-        if get(a:data['opt'], 'stdout', 1)
-            let a:data['jobopt']['out_cb'] = function('s:spawnVimOutCb', [a:data])
-        endif
-        if get(a:data['opt'], 'stderr', 1)
-            let a:data['jobopt']['err_cb'] = function('s:spawnVimErrCb', [a:data])
-        endif
-        if has('patch-8.1.350')
-            let a:data['jobopt']['noblock'] = 1
+        if get(a:data['opt'], 'stdout', 1) | let a:data['jobopt']['out_cb'] = function('s:spawnVimOutCb', [a:data]) | endif
+        if get(a:data['opt'], 'stderr', 1) | let a:data['jobopt']['err_cb'] = function('s:spawnVimErrCb', [a:data]) | endif
+        if has('patch-8.1.350') | let a:data['jobopt']['noblock'] = 1 | endif
+        if l:normalize ==# 'array'
+            let a:data['normalize'] = function('s:spawnNormalizeVimArray')
+        else
+            let a:data['normalize'] = function('s:spawnNormalizeRaw')
         endif
         let l:job = job_start(a:data['cmd'], a:data['jobopt'])
         let l:channel = job_getchannel(l:job)
@@ -1463,6 +1464,20 @@ function! s:spawn(data, start, sink) abort
     endif
 endfunction
 
+function! s:spawnNormalizeRaw(data) abort
+    return a:data
+endfunction
+
+function! s:spawnNormalizeNeovimString(data) abort
+    " convert array to string since neovim uses array split by \n by default
+    return join(a:data, "\n")
+endfunction
+
+function! s:spawnNormalizeVimArray(data) abort
+    " convert string to array since vim uses string by default.
+    return split(a:data, "\n", 1)
+endfunction
+
 function! s:spawnSinkCallback(data, t, ...) abort
     if a:t == 2
         let l:jobid = get(a:data, 'jobid', 0)
@@ -1483,11 +1498,11 @@ function! s:spawnSinkCallback(data, t, ...) abort
 endfunction
 
 function! s:spawnNeovimOnStdout(data, id, d, event) abort
-    call a:data['sink'](1, { 'event': 'stdout', 'data': a:d })
+    call a:data['sink'](1, { 'event': 'stdout', 'data': a:data['normalize'](a:d) })
 endfunction
 
 function! s:spawnNeovimOnStderr(data, id, d, event) abort
-    call a:data['sink'](1, { 'event': 'stderr', 'data': a:d })
+    call a:data['sink'](1, { 'event': 'stderr', 'data': a:data['normalize'](a:d) })
 endfunction
 
 function! s:spawnNeovimOnExit(data, id, d, event) abort
@@ -1498,11 +1513,11 @@ function! s:spawnNeovimOnExit(data, id, d, event) abort
 endfunction
 
 function! s:spawnVimOutCb(data, id, d, ...) abort
-    call a:data['sink'](1, { 'event': 'stdout', 'data': a:d })
+    call a:data['sink'](1, { 'event': 'stdout', 'data': a:data['normalize'](a:d) })
 endfunction
 
 function! s:spawnVimErrCb(data, id, d, ...) abort
-    call a:data['sink'](1, { 'event': 'stderr', 'data': a:d })
+    call a:data['sink'](1, { 'event': 'stderr', 'data': a:data['normalize'](a:d) })
 endfunction
 
 function! s:spawnVimExitCb(data, id, d) abort

--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1407,6 +1407,14 @@ endfunction
 " }}}
 
 " spawn {{{
+" call callbag#spawn(['bash', '-c', 'ls'], {
+"   \ 'stdout': 1,
+"   \ 'stderr': 1,
+"   \ 'exit': 1,
+"   \ 'pid': 1,
+"   \ 'failOnNonZeroExitCode': 1,
+"   \ 'normalize': 'raw' | 'string' | 'array', (defaults to raw)
+"   \ })
 function! callbag#spawn(cmd, ...) abort
     let l:data = { 'cmd': a:cmd, 'opt': a:0 > 0 ? copy(a:000[0]) : {} }
     return function('s:spawn', [l:data])

--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1473,7 +1473,7 @@ function! s:spawnCloseCb(data, id) abort
     endif
 endfunction
 
-function! s:spawnNotifyExit(data)
+function! s:spawnNotifyExit(data) abort
     if get(a:data['opt'], 'exit', 1)
         call a:data['sink'](1, { 'event': 'exit', 'data': a:data['exitcode'] })
     endif

--- a/autoload/callbag.vim
+++ b/autoload/callbag.vim
@@ -1419,7 +1419,7 @@ endfunction
 "   \ 'env': {},
 "   \ })
 "   call s:Stdin(1, 'hi')
-"   call s:Stdin(2, callbag#undefined())
+"   call s:Stdin(2, callbag#undefined()) " requried to close stdin
 function! callbag#spawn(cmd, ...) abort
     let l:data = { 'cmd': a:cmd, 'opt': a:0 > 0 ? copy(a:000[0]) : {} }
     return function('s:spawn', [l:data])

--- a/examples.vim
+++ b/examples.vim
@@ -236,14 +236,17 @@ function! callbag#demo() abort
         echom v:exception . ' ' . v:throwpoint
     endtry
 
+    " let s:Stdin = callbag#makeSubject()
     " call callbag#pipe(
-    "     \ callbag#spawn(['bash', '-c', 'ls']),
+    "     \ callbag#spawn(['bash', '-c', 'read i; echo $i'], { 'stdin': s:Stdin }),
     "     \ callbag#subscribe({
-    "     \   'next':{x->s:log('next', x)},
+    "     \   'next':{x->s:log(['next', x])},
     "     \   'complete':{->s:log('complete')},
-    "     \   'error':{x->s:log('error', x)},
+    "     \   'error':{x->s:log(['error', x])},
     "     \ }),
     "     \ )
+    " call s:Stdin(1, 'hello')
+    " call s:Stdin(2, callbag#undefined())
 
     " Plug 'vim-jp/vital.vim'
     "

--- a/examples.vim
+++ b/examples.vim
@@ -236,6 +236,15 @@ function! callbag#demo() abort
         echom v:exception . ' ' . v:throwpoint
     endtry
 
+    " call callbag#pipe(
+    "     \ callbag#spawn(['bash', '-c', 'ls']),
+    "     \ callbag#subscribe({
+    "     \   'next':{x->s:log('next', x)},
+    "     \   'complete':{->s:log('complete')},
+    "     \   'error':{x->s:log('error', x)},
+    "     \ }),
+    "     \ )
+
     " Plug 'vim-jp/vital.vim'
     "
     " call callbag#pipe(
@@ -253,5 +262,3 @@ function! s:promiseWait(ms)
     let s:Promise = s:V.import('Async.Promise')
     return s:Promise.new({resolve -> timer_start(a:ms, resolve)})
 endfunction
-
-


### PR DESCRIPTION
- [x] Add vim8 support for stdin/stdout/exit
- [x] Add neovim support for stdin/stdout/exit
- [x] Add vim8 support for stdin
- [x] Add neovim support for stdin
- [x] Add `failOnNonZeroExitCode`
- [x] Add option to send `stdout` notification
- [x] Add option to send `stderr` notification
- [x] Add option to send `exit` notification
- [x] Add option to send `start` notification. Should include jobid
- [x] Add option to include processid as part of start notification.
- [x] Add option for stdout/stderr data, i.e. normalize to string, normalize to array or raw. Default to raw so the users opts in as default normalization can cause bad perf impact.
- [x] env support

Usage 1:

```vim
function! s:log(...) abort
    echom json_encode(a:000)
endfunction

call callbag#pipe(
    \ callbag#spawn(['bash', '-c', 'ls']),
    \ callbag#subscribe({
    \   'next':{x->s:log('next', x)},
    \   'complete':{->s:log('complete')},
    \   'error':{x->s:log('error', x)},
    \ }),
    \ )
```

Usage 2: Example with `stdin`.

```vim
function! s:log(...) abort
    echom json_encode(a:000)
endfunction

let s:Stdin = callbag#makeSubject()

call callbag#pipe(
    \ callbag#spawn(['bash', '-c', 'read i; echo $i'], { 'stdin': s:Stdin }),
    \ callbag#subscribe({
    \   'next':{x->s:log('next', x)},
    \   'complete':{->s:log('complete')},
    \   'error':{x->s:log('error', x)},
    \ }),
    \ )

call s:Stdin(1, 'hello')
call s:Stdin(2, callbag#undefined()) " required to close stdin
```